### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,10 @@ jobs:
     name: Lint 👷
     steps:
       - name: Check out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v2
 
       - name: OpenTofu fmt
         run: tofu fmt -recursive -diff -check


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `actions/checkout@v4 → actions/checkout@v7`
- `opentofu/setup-opentofu@v1 → opentofu/setup-opentofu@v2`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code